### PR TITLE
Fix runtime build by including all proxy features

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -106,6 +106,7 @@ std = [
 	"pallet-balances/std",
 	"pallet-collator-selection/std",
 	"pallet-parachain-template/std",
+	"pallet-proxy/std",
 	"pallet-multisig/std",
 	"pallet-session/std",
 	"pallet-sudo/std",
@@ -157,6 +158,7 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
+	"pallet-proxy/runtime-benchmarks",
 ]
 
 try-runtime = [
@@ -176,6 +178,7 @@ try-runtime = [
 	"pallet-multisig/try-runtime",
 	"pallet-parachain-template/try-runtime",
 	"pallet-session/try-runtime",
+	"pallet-proxy/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",


### PR DESCRIPTION
without these changes runtime does not compile because pallet-proxy is leaking `std`

Closes #38

### Follow Up: Fix CI to correctly verify if runtime builds

Highlights #28 by showing that the current CI does NOT check if the runtime builds and this has led to a bug