### PR TITLE
revert code to substrate original

### DIFF
--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,5 +1,13 @@
-use substrate_wasm_builder::WasmBuilder;
-
+#[cfg(feature = "std")]
 fn main() {
-    WasmBuilder::new().with_current_project().export_heap_base().import_memory().build()
+    substrate_wasm_builder::WasmBuilder::new()
+        .with_current_project()
+        .export_heap_base()
+        .import_memory()
+        .build()
 }
+
+/// The wasm builder is deactivated when compiling
+/// this crate for wasm to speed up the compilation.
+#[cfg(not(feature = "std"))]
+fn main() {}


### PR DESCRIPTION
Fixes #79 

Reverts the code to substrate original for `build.rs`. It was changed in #68 due to compilation errors, but I suspect these changes are not related to compilation errors.