### PR TITLE
remove windows from ci tests

### DIFF
--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -14,8 +14,8 @@ on:
       - "**.adoc"
   workflow_dispatch:
     inputs:
-      test-macos-and-windows:
-        description: "run macOS and Windows tests"
+      test-macos:
+        description: "run tests on macOS"
         required: true
         default: false
         type: boolean
@@ -35,14 +35,11 @@ jobs:
         os:
           - ubuntu-22.04
           - macos-12
-          - windows-2022
         run-all:
-          - ${{ inputs.test-macos-and-windows == true || github.ref == 'refs/heads/main' }}
-        exclude: # exclude macos-12 and windows-2022 when the condition is false
+          - ${{ inputs.test-macos == true || github.ref == 'refs/heads/main' }}
+        exclude: # exclude macos-12 when the condition is false
           - run-all: false
             os: macos-12
-          - run-all: false
-            os: windows-2022
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Fixes #47 

I've tried on my Windows machine, and found out that the error on Windows is not specific to our CI setup, but general to all windows machines. 

The details are provided in the issue if you want to take a deeper look.

In short, `polkadot-sdk` does not support Windows, and we should remove `windows` tests from our CI until Windows is supported by the upstream.