### PR TITLE
Generic documentation

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,5 +1,7 @@
 * General Guides
 ** xref:guides/weights_fees.adoc[Weights & Fees]
+* Runtimes
+** xref:runtimes/generic.adoc[Generic Runtime]
 * Runtime Descriptions
 ** xref:runtime/xcm_executor.adoc[XCM Executor]
 * Pallet Specifications

--- a/docs/modules/ROOT/pages/runtimes/generic.adoc
+++ b/docs/modules/ROOT/pages/runtimes/generic.adoc
@@ -1,0 +1,53 @@
+:source-highlighter: highlight.js
+:highlightjs-languages: rust
+:github-icon: pass:[<svg class="icon"><use href="#github-icon"/></svg>]
+
+== Purpose
+
+Polkadot Runtime Template is constructed with the purpose of providing the most generic template that is working out of the box.
+
+The pallet list is constructed by the contributions of Parity, the community, and OpenZeppelin.
+
+Our motivation for crafting the pallet list was to be as minimalistic as possible,
+whilst preserving the most important pallets that are used in the Polkadot ecosystem.
+
+We designed this template to be generic, so that it can be used as a starting point for any other template,
+and we aim to base our future templates off of this one.
+
+To demystify the hard concepts, we provided a documentation, in which you can find:
+* explanation of the pallets that are used in this template (purpose, terminology, configuration, dispatchables, etc.),
+* general guides regarding this template,
+* runtime related guides,
+* and miscellaneous topics.
+
+=== Comparison with other templates
+
+// TODO:
+
+== Configuration
+
+// TODO:
+
+// List of pallets with their config description
+
+=== `++pallet_name++` link:https://google.com[{github-icon},role=heading-link]
+[%collapsible]
+====
+Freeform description of the reason why this pallet was added.
+
+```rust
+impl pallet_name::Config for Runtime {
+    type Config1 = Type1;
+    type Config2 = Type2;
+}
+```
+
+* Description of `Type1` if needed
+* Description of `Type2` if needed
+
+**Relations**
+
+Description of which pallets will get affected if this pallet is going to be removed or changed
+====
+
+

--- a/docs/modules/ROOT/pages/runtimes/generic.adoc
+++ b/docs/modules/ROOT/pages/runtimes/generic.adoc
@@ -1,6 +1,7 @@
 :source-highlighter: highlight.js
 :highlightjs-languages: rust
 :github-icon: pass:[<svg class="icon"><use href="#github-icon"/></svg>]
+= Generic Runtime
 
 == Purpose
 
@@ -23,110 +24,98 @@ To demystify the hard concepts, we provided a documentation, in which you can fi
 == Configuration
 
 === System Support
+.click to expand
 [%collapsible]
 ====
-===== `++frame_system++` link:https://paritytech.github.io/polkadot-sdk/master/frame_system/index.html#
-`frame_system` is responsible from creating the runtime, initializing the storage, and providing the base functionality for the runtime.
 
-===== `++cumulus_pallet_parachain_system++` link:https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_parachain_system/index.html#
-`cumulus_pallet_parachain_system` handles low-level details of being a parachain.
+* https://paritytech.github.io/polkadot-sdk/master/frame_system/index.html#[frame_system] is responsible from creating the runtime, initializing the storage, and providing the base functionality for the runtime.
 
-===== `++pallet_timestamp++` link:https://paritytech.github.io/polkadot-sdk/master/pallet_timestamp/index.html#
-`pallet_timestamp` provides a way for consensus systems to set and check the onchain time.
+* https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_parachain_system/index.html#[cumulus_pallet_parachain_system] handles low-level details of being a parachain.
 
-===== `++parachain_info++` link:https://docs.rs/staging-parachain-info/latest/staging_parachain_info/index.html#
-`parachain_info` provides a way for parachains to report their parachain id and the relay chain block number.
+* https://paritytech.github.io/polkadot-sdk/master/pallet_timestamp/index.html#[pallet_timestamp] provides a way for consensus systems to set and check the onchain time.
 
-===== `++pallet_utility++` link:https://paritytech.github.io/polkadot-sdk/master/pallet_utility/index.html#
-`pallet_utility` contains two basic pieces of functionality:
+* https://docs.rs/staging-parachain-info/latest/staging_parachain_info/index.html#[parachain_info] provides a way for parachains to report their parachain id and the relay chain block number.
 
-* Batch dispatch: A stateless operation, allowing any origin to execute multiple calls in a single dispatch. This can be useful to amalgamate proposals, combining `set_code` with corresponding `set_storage`s, for efficient multiple payouts with just a single signature verify, or in combination with one of the other two dispatch functionality.
-**https://paritytech.github.io/polkadot-sdk/master/pallet_utility/pallet/struct.Pallet.html#method.force_batch[force_batch]: Sends a batch of dispatch calls. Errors are allowed and won’t interrupt
-**https://paritytech.github.io/polkadot-sdk/master/pallet_utility/pallet/struct.Pallet.html#method.batch[batch]: Sends a batch of dispatch calls. This will return `Ok` in all circumstances. To determine the success of the batch, an event is deposited. If a call failed and the batch was interrupted, then the `BatchInterrupted` event is deposited, along with the number of successful calls made and the error of the failed call. If all were successful, then the `BatchCompleted` event is deposited.
-**https://paritytech.github.io/polkadot-sdk/master/pallet_utility/pallet/struct.Pallet.html#method.batch_all[batch_all]: Send a batch of dispatch calls and atomically execute them. The whole transaction will rollback and fail if any of the calls failed.
-* Pseudonymal dispatch: A stateless operation, allowing a signed origin to execute a call from an alternative signed origin. Each account has 2 * 2**16 possible “pseudonyms” (alternative account IDs) and these can be stacked. This can be useful as a key management tool, where you need multiple distinct accounts (e.g. as controllers for many staking accounts), but where it’s perfectly fine to have each of them controlled by the same underlying keypair. Derivative accounts are, for the purposes of proxy filtering considered exactly the same as the origin and are thus hampered with the origin’s filters.
+* https://paritytech.github.io/polkadot-sdk/master/pallet_utility/index.html#[pallet_utility] contains two basic pieces of functionality:
+
+** Batch dispatch: A stateless operation, allowing any origin to execute multiple calls in a single dispatch. This can be useful to amalgamate proposals, combining `set_code` with corresponding `set_storage`s, for efficient multiple payouts with just a single signature verify, or in combination with one of the other two dispatch functionality.
+*** https://paritytech.github.io/polkadot-sdk/master/pallet_utility/pallet/struct.Pallet.html#method.force_batch[force_batch]: Sends a batch of dispatch calls. Errors are allowed and won’t interrupt
+*** https://paritytech.github.io/polkadot-sdk/master/pallet_utility/pallet/struct.Pallet.html#method.batch[batch]: Sends a batch of dispatch calls. This will return `Ok` in all circumstances. To determine the success of the batch, an event is deposited. If a call failed and the batch was interrupted, then the `BatchInterrupted` event is deposited, along with the number of successful calls made and the error of the failed call. If all were successful, then the `BatchCompleted` event is deposited.
+*** https://paritytech.github.io/polkadot-sdk/master/pallet_utility/pallet/struct.Pallet.html#method.batch_all[batch_all]: Send a batch of dispatch calls and atomically execute them. The whole transaction will rollback and fail if any of the calls failed.
+** Pseudonymal dispatch: A stateless operation, allowing a signed origin to execute a call from an alternative signed origin. Each account has 2 * 2**16 possible “pseudonyms” (alternative account IDs) and these can be stacked. This can be useful as a key management tool, where you need multiple distinct accounts (e.g. as controllers for many staking accounts), but where it’s perfectly fine to have each of them controlled by the same underlying keypair. Derivative accounts are, for the purposes of proxy filtering considered exactly the same as the origin and are thus hampered with the origin’s filters.
 
 ====
 
 === Monetary
+.click to expand
 [%collapsible]
 ====
-===== `++pallet_balances++` link:https://docs.rs/pallet-balances/latest/pallet_balances/#
-`pallet_balances` provides functions for:
-* Getting and setting free balances.
-* Retrieving total, reserved and unreserved balances.
-* Repatriating a reserved balance to a beneficiary account that exists.
-* Transferring a balance between accounts (when not reserved).
-* Slashing an account balance.
-* Account creation and removal.
-* Managing total issuance.
-* Setting and managing locks.
 
-===== `++pallet_transaction_payment++` link:https://docs.rs/pallet-transaction-payment/latest/pallet_transaction_payment/#
-`pallet_transaction_payment` provides the basic logic needed to pay the absolute minimum amount needed for a transaction to be included. This includes:
-* *base fee*: This is the minimum amount a user pays for a transaction. It is declared as a base *weight* in the runtime and converted to a fee using `WeightToFee`.
-* *weight fee*: A fee proportional to amount of weight a transaction consumes.
-* *length fee*: A fee proportional to the encoded length of the transaction.
-* *tip*: An optional tip. Tip increases the priority of the transaction, giving it a higher chance to be included by the transaction queue.
+* https://docs.rs/pallet-balances/latest/pallet_balances/#[pallet_balances] provides functions for:
+** Getting and setting free balances.
+** Retrieving total, reserved and unreserved balances.
+** Repatriating a reserved balance to a beneficiary account that exists.
+** Transferring a balance between accounts (when not reserved).
+** Slashing an account balance.
+** Account creation and removal.
+** Managing total issuance.
+** Setting and managing locks.
+
+* https://docs.rs/pallet-transaction-payment/latest/pallet_transaction_payment/#[pallet_transaction_payment] provides the basic logic needed to pay the absolute minimum amount needed for a transaction to be included. This includes:
+** *base fee*: This is the minimum amount a user pays for a transaction. It is declared as a base *weight* in the runtime and converted to a fee using `WeightToFee`.
+** *weight fee*: A fee proportional to amount of weight a transaction consumes.
+** *length fee*: A fee proportional to the encoded length of the transaction.
+** *tip*: An optional tip. Tip increases the priority of the transaction, giving it a higher chance to be included by the transaction queue.
 
 ====
 
 === Governance
+.click to expand
 [%collapsible]
 ====
-===== `++pallet_sudo++` link:https://docs.rs/pallet-sudo/latest/pallet_sudo/#
-`pallet_sudo` provides a way to execute privileged runtime calls using a specified sudo (“superuser do”) account.
+* https://docs.rs/pallet-sudo/latest/pallet_sudo/#[pallet_sudo] provides a way to execute privileged runtime calls using a specified sudo (“superuser do”) account.
 
-===== `++pallet_multisig++` link:https://docs.rs/pallet-multisig/latest/pallet_multisig/#
-`pallet_multisig` enables multi-signature operations in your runtime. This module allows multiple signed origins (accounts) to coordinate and dispatch a call. For the call to execute, the threshold number of accounts from the set (signatories) must approve it.
+* https://docs.rs/pallet-multisig/latest/pallet_multisig/#[pallet_multisig] enables multi-signature operations in your runtime. This module allows multiple signed origins (accounts) to coordinate and dispatch a call. For the call to execute, the threshold number of accounts from the set (signatories) must approve it.
 
-===== `++pallet_proxy++` link:https://docs.rs/pallet-proxy/latest/pallet_proxy/#
-`pallet_proxy` enables delegation of rights to execute certain call types from one origin to another.
+* https://docs.rs/pallet-proxy/latest/pallet_proxy/#[pallet_proxy] enables delegation of rights to execute certain call types from one origin to another.
 
 ====
 
 === Collator support
+.click to expand
 [%collapsible]
 ====
-===== `++pallet_authorship++` link:https://docs.rs/pallet-authorship/latest/pallet_authorship/#
-`pallet_authorship` provides authorship tracking for FRAME runtimes. This tracks the current author of the block and recent uncles.
+* https://docs.rs/pallet-authorship/latest/pallet_authorship/#[pallet_authorship] provides authorship tracking for FRAME runtimes. This tracks the current author of the block and recent uncles.
 
-===== `++pallet_collator_selection++` link:https://paritytech.github.io/polkadot-sdk/master/pallet_collator_selection/index.html#
-`pallet_collator_selection` - manages the collators of a parachain. **Collation is *not* a secure activity** and this pallet does not implement any game-theoretic mechanisms to meet BFT safety assumptions of the chosen set. This pallet can:
-* set invulnerable candidates (fixed candidates)
-* set desired candidates (ideal number of non-fixed)
-* set candidacy bond
-* remove invulnerability (turn candidate into not fixed)
-* and many more (all related to collators)
+* https://paritytech.github.io/polkadot-sdk/master/pallet_collator_selection/index.html#[pallet_collator_selection] - manages the collators of a parachain. **Collation is *not* a secure activity** and this pallet does not implement any game-theoretic mechanisms to meet BFT safety assumptions of the chosen set. This pallet can:
+** set invulnerable candidates (fixed candidates)
+** set desired candidates (ideal number of non-fixed)
+** set candidacy bond
+** remove invulnerability (turn candidate into not fixed)
+** and many more (all related to collators)
 
-===== `++pallet_session++` link:https://paritytech.github.io/polkadot-sdk/master/pallet_session/index.html#
-`pallet_session` allows validators to manage their session keys, provides a function for changing the session length, and handles session rotation.
+* https://paritytech.github.io/polkadot-sdk/master/pallet_session/index.html#[pallet_session] allows validators to manage their session keys, provides a function for changing the session length, and handles session rotation.
 
-===== `++pallet_aura++` link:https://docs.rs/pallet-aura/latest/pallet_aura/#
-`pallet_aura` extends Aura consensus by managing offline reporting. It can:
-* get the current slot
-* get the slot duration
-* change and initialize authorities
-* ensure the correctness of the state of this pallet
+* https://docs.rs/pallet-aura/latest/pallet_aura/#[pallet_aura] extends Aura consensus by managing offline reporting. It can:
+** get the current slot
+** get the slot duration
+** change and initialize authorities
+** ensure the correctness of the state of this pallet
 
-===== `++cumulus_pallet_aura_ext++` link:https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_aura_ext/index.html#
-`cumulus_pallet_aura_ext` extends the Substrate AuRa pallet to make it compatible with parachains. It provides the Pallet, the Config and the GenesisConfig.
+* https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_aura_ext/index.html#[cumulus_pallet_aura_ext] extends the Substrate AuRa pallet to make it compatible with parachains. It provides the Pallet, the Config and the GenesisConfig.
 
 ====
 
 === XCM Helpers
+.click to expand
 [%collapsible]
 ====
-===== `++cumulus_pallet_xcmp_queue++` link:https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_xcmp_queue/index.html#
-`cumulus_pallet_xcmp_queue` Responsible for the Queues (both incoming and outgoing) for XCMP messages. This pallet does not actually receive or send messages. Its responsibility is to place the incoming and outgoing XCMP messages in their respective queues and manage these queues.
+* https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_xcmp_queue/index.html#[cumulus_pallet_xcmp_queue] Responsible for the Queues (both incoming and outgoing) for XCMP messages. This pallet does not actually receive or send messages. Its responsibility is to place the incoming and outgoing XCMP messages in their respective queues and manage these queues.
 
-===== `++pallet_xcm++` link:https://docs.rs/pallet-xcm/6.0.0/pallet_xcm/#
-`pallet_xcm` is responsible for filtering, routing, and executing incoming XCM.
+* https://docs.rs/pallet-xcm/6.0.0/pallet_xcm/#[pallet_xcm] is responsible for filtering, routing, and executing incoming XCM.
 
-===== `++cumulus_pallet_xcm++` link:https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_xcm/index.html#
-`cumulus_pallet_xcm` is responsible from detecting and ensuring whether XCM's are coming from *Relay* or *Sibling* chain.
+* https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_xcm/index.html#[cumulus_pallet_xcm] is responsible from detecting and ensuring whether XCM's are coming from *Relay* or *Sibling* chain.
 
-===== `++cumulus_pallet_dmp_queue++` link:https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_dmp_queue/index.html#
-`cumulus_pallet_dmp_queue` is **DEPRECATED**. This pallet used to implement a message queue for downward messages from the relay-chain.
+* https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_dmp_queue/index.html#[cumulus_pallet_dmp_queue] is **DEPRECATED**. This pallet used to implement a message queue for downward messages from the relay-chain.
 
 ====

--- a/docs/modules/ROOT/pages/runtimes/generic.adoc
+++ b/docs/modules/ROOT/pages/runtimes/generic.adoc
@@ -11,7 +11,7 @@ The pallet list is constructed by the contributions of Parity, the community, an
 Our motivation for crafting the pallet list was to be as minimalistic as possible,
 whilst preserving the most important pallets that are used in the Polkadot ecosystem.
 
-We designed this template to be generic, so that it can be used as a starting point for any other template,
+We designed this template to be generic, so that it can be used as a starting point for any other project/template,
 and we aim to base our future templates off of this one.
 
 To demystify the hard concepts, we provided a documentation, in which you can find:
@@ -26,28 +26,72 @@ To demystify the hard concepts, we provided a documentation, in which you can fi
 
 == Configuration
 
-// TODO:
-
-// List of pallets with their config description
-
-=== `++pallet_name++` link:https://google.com[{github-icon},role=heading-link]
+=== System Support
 [%collapsible]
 ====
-Freeform description of the reason why this pallet was added.
+===== `++frame_system++` link:https://paritytech.github.io/polkadot-sdk/master/frame_system/index.html#
+`frame_system` is responsible from creating the runtime, initializing the storage, and providing the base functionality for the runtime.
 
-```rust
-impl pallet_name::Config for Runtime {
-    type Config1 = Type1;
-    type Config2 = Type2;
-}
-```
+===== `++cumulus_pallet_parachain_system++` link:https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_parachain_system/index.html#
+`cumulus_pallet_parachain_system` handles low-level details of being a parachain.
 
-* Description of `Type1` if needed
-* Description of `Type2` if needed
+===== `++pallet_timestamp++` link:https://paritytech.github.io/polkadot-sdk/master/pallet_timestamp/index.html#
+`pallet_timestamp` provides a way for consensus systems to set and check the onchain time.
 
-**Relations**
+===== `++parachain_info++` link:https://docs.rs/staging-parachain-info/latest/staging_parachain_info/index.html#
+`parachain_info` provides a way for parachains to report their parachain id and the relay chain block number.
 
-Description of which pallets will get affected if this pallet is going to be removed or changed
+===== `++pallet_utility++` link:https://paritytech.github.io/polkadot-sdk/master/pallet_utility/index.html#
+`pallet_utility` contains two basic pieces of functionality:
+
+* Batch dispatch: A stateless operation, allowing any origin to execute multiple calls in a single dispatch. This can be useful to amalgamate proposals, combining `set_code` with corresponding `set_storage`s, for efficient multiple payouts with just a single signature verify, or in combination with one of the other two dispatch functionality.
+**https://paritytech.github.io/polkadot-sdk/master/pallet_utility/pallet/struct.Pallet.html#method.force_batch[force_batch]: Sends a batch of dispatch calls. Errors are allowed and won’t interrupt
+**https://paritytech.github.io/polkadot-sdk/master/pallet_utility/pallet/struct.Pallet.html#method.batch[batch]: Sends a batch of dispatch calls. This will return `Ok` in all circumstances. To determine the success of the batch, an event is deposited. If a call failed and the batch was interrupted, then the `BatchInterrupted` event is deposited, along with the number of successful calls made and the error of the failed call. If all were successful, then the `BatchCompleted` event is deposited.
+**https://paritytech.github.io/polkadot-sdk/master/pallet_utility/pallet/struct.Pallet.html#method.batch_all[batch_all]: Send a batch of dispatch calls and atomically execute them. The whole transaction will rollback and fail if any of the calls failed.
+* Pseudonymal dispatch: A stateless operation, allowing a signed origin to execute a call from an alternative signed origin. Each account has 2 * 2**16 possible “pseudonyms” (alternative account IDs) and these can be stacked. This can be useful as a key management tool, where you need multiple distinct accounts (e.g. as controllers for many staking accounts), but where it’s perfectly fine to have each of them controlled by the same underlying keypair. Derivative accounts are, for the purposes of proxy filtering considered exactly the same as the origin and are thus hampered with the origin’s filters.
+
 ====
+
+=== Monetary
+[%collapsible]
+====
+===== `++pallet_balances++` link:https://docs.rs/pallet-balances/latest/pallet_balances/#
+`pallet_balances`  provides functions for:
+* Getting and setting free balances.
+* Retrieving total, reserved and unreserved balances.
+* Repatriating a reserved balance to a beneficiary account that exists.
+* Transferring a balance between accounts (when not reserved).
+* Slashing an account balance.
+* Account creation and removal.
+* Managing total issuance.
+* Setting and managing locks.
+
+===== `++pallet_transaction_payment++` link:https://docs.rs/pallet-transaction-payment/latest/pallet_transaction_payment/#
+`pallet_transaction_payment` provides the basic logic needed to pay the absolute minimum amount needed for a transaction to be included. This includes:
+* *base fee*: This is the minimum amount a user pays for a transaction. It is declared as a base *weight* in the runtime and converted to a fee using `WeightToFee`.
+* *weight fee*: A fee proportional to amount of weight a transaction consumes.
+* *length fee*: A fee proportional to the encoded length of the transaction.
+* *tip*: An optional tip. Tip increases the priority of the transaction, giving it a higher chance to be included by the transaction queue.
+
+====
+
+
+// Governance
+Sudo: pallet_sudo = 15,
+Multisig: pallet_multisig = 16,
+Proxy: pallet_proxy = 17,
+
+// Collator support. The order of these 4 are important and shall not change.
+Authorship: pallet_authorship = 20,
+CollatorSelection: pallet_collator_selection = 21,
+Session: pallet_session = 22,
+Aura: pallet_aura = 23,
+AuraExt: cumulus_pallet_aura_ext = 24,
+
+// XCM helpers.
+XcmpQueue: cumulus_pallet_xcmp_queue = 30,
+PolkadotXcm: pallet_xcm = 31,
+CumulusXcm: cumulus_pallet_xcm = 32,
+DmpQueue: cumulus_pallet_dmp_queue = 33,
 
 

--- a/docs/modules/ROOT/pages/runtimes/generic.adoc
+++ b/docs/modules/ROOT/pages/runtimes/generic.adoc
@@ -20,10 +20,6 @@ To demystify the hard concepts, we provided a documentation, in which you can fi
 * runtime related guides,
 * and miscellaneous topics.
 
-=== Comparison with other templates
-
-// TODO:
-
 == Configuration
 
 === System Support
@@ -56,7 +52,7 @@ To demystify the hard concepts, we provided a documentation, in which you can fi
 [%collapsible]
 ====
 ===== `++pallet_balances++` link:https://docs.rs/pallet-balances/latest/pallet_balances/#
-`pallet_balances`  provides functions for:
+`pallet_balances` provides functions for:
 * Getting and setting free balances.
 * Retrieving total, reserved and unreserved balances.
 * Repatriating a reserved balance to a beneficiary account that exists.
@@ -75,23 +71,62 @@ To demystify the hard concepts, we provided a documentation, in which you can fi
 
 ====
 
+=== Governance
+[%collapsible]
+====
+===== `++pallet_sudo++` link:https://docs.rs/pallet-sudo/latest/pallet_sudo/#
+`pallet_sudo` provides a way to execute privileged runtime calls using a specified sudo (“superuser do”) account.
 
-// Governance
-Sudo: pallet_sudo = 15,
-Multisig: pallet_multisig = 16,
-Proxy: pallet_proxy = 17,
+===== `++pallet_multisig++` link:https://docs.rs/pallet-multisig/latest/pallet_multisig/#
+`pallet_multisig` enables multi-signature operations in your runtime. This module allows multiple signed origins (accounts) to coordinate and dispatch a call. For the call to execute, the threshold number of accounts from the set (signatories) must approve it.
 
-// Collator support. The order of these 4 are important and shall not change.
-Authorship: pallet_authorship = 20,
-CollatorSelection: pallet_collator_selection = 21,
-Session: pallet_session = 22,
-Aura: pallet_aura = 23,
-AuraExt: cumulus_pallet_aura_ext = 24,
+===== `++pallet_proxy++` link:https://docs.rs/pallet-proxy/latest/pallet_proxy/#
+`pallet_proxy` enables delegation of rights to execute certain call types from one origin to another.
 
-// XCM helpers.
-XcmpQueue: cumulus_pallet_xcmp_queue = 30,
-PolkadotXcm: pallet_xcm = 31,
-CumulusXcm: cumulus_pallet_xcm = 32,
-DmpQueue: cumulus_pallet_dmp_queue = 33,
+====
 
+=== Collator support
+[%collapsible]
+====
+===== `++pallet_authorship++` link:https://docs.rs/pallet-authorship/latest/pallet_authorship/#
+`pallet_authorship` provides authorship tracking for FRAME runtimes. This tracks the current author of the block and recent uncles.
 
+===== `++pallet_collator_selection++` link:https://paritytech.github.io/polkadot-sdk/master/pallet_collator_selection/index.html#
+`pallet_collator_selection` - manages the collators of a parachain. **Collation is *not* a secure activity** and this pallet does not implement any game-theoretic mechanisms to meet BFT safety assumptions of the chosen set. This pallet can:
+* set invulnerable candidates (fixed candidates)
+* set desired candidates (ideal number of non-fixed)
+* set candidacy bond
+* remove invulnerability (turn candidate into not fixed)
+* and many more (all related to collators)
+
+===== `++pallet_session++` link:https://paritytech.github.io/polkadot-sdk/master/pallet_session/index.html#
+`pallet_session` allows validators to manage their session keys, provides a function for changing the session length, and handles session rotation.
+
+===== `++pallet_aura++` link:https://docs.rs/pallet-aura/latest/pallet_aura/#
+`pallet_aura` extends Aura consensus by managing offline reporting. It can:
+* get the current slot
+* get the slot duration
+* change and initialize authorities
+* ensure the correctness of the state of this pallet
+
+===== `++cumulus_pallet_aura_ext++` link:https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_aura_ext/index.html#
+`cumulus_pallet_aura_ext` extends the Substrate AuRa pallet to make it compatible with parachains. It provides the Pallet, the Config and the GenesisConfig.
+
+====
+
+=== XCM Helpers
+[%collapsible]
+====
+===== `++cumulus_pallet_xcmp_queue++` link:https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_xcmp_queue/index.html#
+`cumulus_pallet_xcmp_queue` Responsible for the Queues (both incoming and outgoing) for XCMP messages. This pallet does not actually receive or send messages. Its responsibility is to place the incoming and outgoing XCMP messages in their respective queues and manage these queues.
+
+===== `++pallet_xcm++` link:https://docs.rs/pallet-xcm/6.0.0/pallet_xcm/#
+`pallet_xcm` is responsible for filtering, routing, and executing incoming XCM.
+
+===== `++cumulus_pallet_xcm++` link:https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_xcm/index.html#
+`cumulus_pallet_xcm` is responsible from detecting and ensuring whether XCM's are coming from *Relay* or *Sibling* chain.
+
+===== `++cumulus_pallet_dmp_queue++` link:https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_dmp_queue/index.html#
+`cumulus_pallet_dmp_queue` is **DEPRECATED**. This pallet used to implement a message queue for downward messages from the relay-chain.
+
+====

--- a/docs/modules/ROOT/pages/runtimes/generic.adoc
+++ b/docs/modules/ROOT/pages/runtimes/generic.adoc
@@ -36,6 +36,10 @@ To demystify the hard concepts, we provided a documentation, in which you can fi
 
 * https://docs.rs/staging-parachain-info/latest/staging_parachain_info/index.html#[parachain_info] provides a way for parachains to report their parachain id and the relay chain block number.
 
+* https://docs.rs/pallet-multisig/latest/pallet_multisig/#[pallet_multisig] enables multi-signature operations in your runtime. This module allows multiple signed origins (accounts) to coordinate and dispatch a call. For the call to execute, the threshold number of accounts from the set (signatories) must approve it.
+
+* https://docs.rs/pallet-proxy/latest/pallet_proxy/#[pallet_proxy] enables delegation of rights to execute certain call types from one origin to another.
+
 * https://paritytech.github.io/polkadot-sdk/master/pallet_utility/index.html#[pallet_utility] contains two basic pieces of functionality:
 
 ** Batch dispatch: A stateless operation, allowing any origin to execute multiple calls in a single dispatch. This can be useful to amalgamate proposals, combining `set_code` with corresponding `set_storage`s, for efficient multiple payouts with just a single signature verify, or in combination with one of the other two dispatch functionality.
@@ -73,11 +77,8 @@ To demystify the hard concepts, we provided a documentation, in which you can fi
 .click to expand
 [%collapsible]
 ====
+
 * https://docs.rs/pallet-sudo/latest/pallet_sudo/#[pallet_sudo] provides a way to execute privileged runtime calls using a specified sudo (“superuser do”) account.
-
-* https://docs.rs/pallet-multisig/latest/pallet_multisig/#[pallet_multisig] enables multi-signature operations in your runtime. This module allows multiple signed origins (accounts) to coordinate and dispatch a call. For the call to execute, the threshold number of accounts from the set (signatories) must approve it.
-
-* https://docs.rs/pallet-proxy/latest/pallet_proxy/#[pallet_proxy] enables delegation of rights to execute certain call types from one origin to another.
 
 ====
 
@@ -85,6 +86,7 @@ To demystify the hard concepts, we provided a documentation, in which you can fi
 .click to expand
 [%collapsible]
 ====
+
 * https://docs.rs/pallet-authorship/latest/pallet_authorship/#[pallet_authorship] provides authorship tracking for FRAME runtimes. This tracks the current author of the block and recent uncles.
 
 * https://paritytech.github.io/polkadot-sdk/master/pallet_collator_selection/index.html#[pallet_collator_selection] - manages the collators of a parachain. **Collation is *not* a secure activity** and this pallet does not implement any game-theoretic mechanisms to meet BFT safety assumptions of the chosen set. This pallet can:
@@ -110,6 +112,7 @@ To demystify the hard concepts, we provided a documentation, in which you can fi
 .click to expand
 [%collapsible]
 ====
+
 * https://paritytech.github.io/polkadot-sdk/master/cumulus_pallet_xcmp_queue/index.html#[cumulus_pallet_xcmp_queue] Responsible for the Queues (both incoming and outgoing) for XCMP messages. This pallet does not actually receive or send messages. Its responsibility is to place the incoming and outgoing XCMP messages in their respective queues and manage these queues.
 
 * https://docs.rs/pallet-xcm/6.0.0/pallet_xcm/#[pallet_xcm] is responsible for filtering, routing, and executing incoming XCM.

--- a/docs/templates/runtime.adoc
+++ b/docs/templates/runtime.adoc
@@ -1,6 +1,7 @@
 :source-highlighter: highlight.js
 :highlightjs-languages: rust
 :github-icon: pass:[<svg class="icon"><use href="#github-icon"/></svg>]
+= Runtime Name
 
 == Purpose
 
@@ -15,6 +16,16 @@ Freeform description of runtime purpose
 ====
 ===== `++pallet_name++` link:https://google.com[{github-icon},role=heading-link]
 Freeform description of the reason why this pallet was added.
+
+Freeform description may include important configuration parameters as:
+impl pallet_name::Config for Runtime {
+    type Config1 = Type1;
+    type Config2 = Type2;
+}
+```
+
+* Description of `Type1` if needed
+* Description of `Type2` if needed
 ====
 
 

--- a/docs/templates/runtime.adoc
+++ b/docs/templates/runtime.adoc
@@ -10,22 +10,13 @@ Freeform description of runtime purpose
 
 // List of pallets with their config description
 
-=== `++pallet_name++` link:https://google.com[{github-icon},role=heading-link]
-
-Freeform description of the reason why this pallet was added.
+=== Pallet Category
 [%collapsible]
 ====
-```rust
-impl pallet_name::Config for Runtime {
-    type Config1 = Type1;
-    type Config2 = Type2;
-}
-```
-
-* Description of `Type1` if needed
-* Description of `Type2` if needed
-
-**Relations**
-
-Description of which pallets will get affected if this pallet is going to be removed or changed
+===== `++pallet_name++` link:https://google.com[{github-icon},role=heading-link]
+Freeform description of the reason why this pallet was added.
 ====
+
+
+=== Important Config Changes Specific to This Template
+

--- a/docs/templates/runtime.adoc
+++ b/docs/templates/runtime.adoc
@@ -1,7 +1,6 @@
 :source-highlighter: highlight.js
 :highlightjs-languages: rust
 :github-icon: pass:[<svg class="icon"><use href="#github-icon"/></svg>]
-= Pallet Name
 
 == Purpose
 
@@ -14,7 +13,8 @@ Freeform description of runtime purpose
 === `++pallet_name++` link:https://google.com[{github-icon},role=heading-link]
 
 Freeform description of the reason why this pallet was added.
-
+[%collapsible]
+====
 ```rust
 impl pallet_name::Config for Runtime {
     type Config1 = Type1;
@@ -28,3 +28,4 @@ impl pallet_name::Config for Runtime {
 **Relations**
 
 Description of which pallets will get affected if this pallet is going to be removed or changed
+====

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -585,21 +585,21 @@ impl pallet_utility::Config for Runtime {
 construct_runtime!(
     pub enum Runtime
     {
-        // System support
+        // System support stuff.
         System: frame_system = 0,
         ParachainSystem: cumulus_pallet_parachain_system = 1,
         Timestamp: pallet_timestamp = 2,
         ParachainInfo: parachain_info = 3,
-        Utility: pallet_utility = 4,
+        Proxy: pallet_proxy = 4,
+        Utility: pallet_utility = 5,
 
-        // Monetary
+        // Monetary stuff.
         Balances: pallet_balances = 10,
         TransactionPayment: pallet_transaction_payment = 11,
 
         // Governance
         Sudo: pallet_sudo = 15,
         Multisig: pallet_multisig = 16,
-        Proxy: pallet_proxy = 17,
 
         // Collator support. The order of these 4 are important and shall not change.
         Authorship: pallet_authorship = 20,
@@ -608,7 +608,7 @@ construct_runtime!(
         Aura: pallet_aura = 23,
         AuraExt: cumulus_pallet_aura_ext = 24,
 
-        // XCM helpers
+        // XCM helpers.
         XcmpQueue: cumulus_pallet_xcmp_queue = 30,
         PolkadotXcm: pallet_xcm = 31,
         CumulusXcm: cumulus_pallet_xcm = 32,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -585,21 +585,21 @@ impl pallet_utility::Config for Runtime {
 construct_runtime!(
     pub enum Runtime
     {
-        // System support stuff.
+        // System support
         System: frame_system = 0,
         ParachainSystem: cumulus_pallet_parachain_system = 1,
         Timestamp: pallet_timestamp = 2,
         ParachainInfo: parachain_info = 3,
-        Proxy: pallet_proxy = 4,
-        Utility: pallet_utility = 5,
+        Utility: pallet_utility = 4,
 
-        // Monetary stuff.
+        // Monetary
         Balances: pallet_balances = 10,
         TransactionPayment: pallet_transaction_payment = 11,
 
         // Governance
         Sudo: pallet_sudo = 15,
         Multisig: pallet_multisig = 16,
+        Proxy: pallet_proxy = 17,
 
         // Collator support. The order of these 4 are important and shall not change.
         Authorship: pallet_authorship = 20,
@@ -608,7 +608,7 @@ construct_runtime!(
         Aura: pallet_aura = 23,
         AuraExt: cumulus_pallet_aura_ext = 24,
 
-        // XCM helpers.
+        // XCM helpers
         XcmpQueue: cumulus_pallet_xcmp_queue = 30,
         PolkadotXcm: pallet_xcm = 31,
         CumulusXcm: cumulus_pallet_xcm = 32,


### PR DESCRIPTION
Fixes #61 

There are some modifications that I've made. I'm going to explain them below. If you disagree with them, feel free to comment, or we can discuss them on a meeting.

For the `runtime template` doc:
- I removed config description for each pallet
    - it would make the runtime doc too long 
    - the configs for important pallets are already explained in their respective docs
    - I know that the reason to include config in runtime docs is to explain what is special about its config. However, explaining the config for each pallet is an overkill imo. 
    - so, I put another section for *important config changes specific to this runtime`
- for generic runtime documentation, comparing it with other templates does not serve any purpose imo
- moved `pallet proxy` from `system` to `governance`, to make it consistent with `multisig` and `sudo`. If you think they should all be in `system`, that is also acceptable.


