### PR TITLE
Ci test

### DIFF
--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -54,9 +54,6 @@ jobs:
       - name: install rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Add required rustup component
-        run: rustup component add rust-src 
-
       - name: Install toml-sort
         run: cargo install --git https://github.com/4meta5/toml_sort
       - name: Add file permissions for toml-sort

--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: install rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rust-src
 
       - name: Install toml-sort
         run: cargo install --git https://github.com/4meta5/toml_sort


### PR DESCRIPTION
Fixes #112 

My wild guess: adding `rust-src` via plain `rustup` command probably caused some conflicts in CI.
This PR adds `rust-src` via the github action we are using for the rust toolchain (maintained by dtolnay).