### PR TITLE
remove redundant action

### DIFF
--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -73,9 +73,6 @@ jobs:
       - name: Run tests
         run: cargo test --release
 
-      - name: Check build
-        run: cargo check --release
-
       - name: Check clippy
         run: cargo clippy --release --locked --all-targets -- -D warnings
 


### PR DESCRIPTION
Fixes #119 

Explanation is present in the issue, but TL;DR:
`clippy` is a superset of `check` command, and now both of them are using `--release` flag, which makes `check` command redundant.