### PR TITLE
Fix cargo toml formatting and bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7151,7 +7151,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-template-node"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "clap",
  "color-print",
@@ -7209,7 +7209,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-template-runtime"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "assets-common",
  "cumulus-pallet-aura-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,20 @@
 [workspace]
-members = ["node", "runtime", "template-fuzzer"]
+members = [ "node", "runtime", "template-fuzzer" ]
 resolver = "2"
 
 [workspace.package]
-authors = ["OpenZeppelin"]
+authors = [ "OpenZeppelin" ]
 description = "Runtime template(s) for Polkadot Para{chains, cores}"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/OpenZeppelin/polkadot-runtime-template"
 
 [workspace.dependencies]
-clap = { version = "4.4.6", features = ["derive"] }
+clap = { version = "4.4.6", features = [ "derive" ] }
 color-print = "0.3.4"
 futures = "0.3.28"
 hex-literal = "0.4.1"
-jsonrpsee = { version = "0.20.3", features = ["server"] }
+jsonrpsee = { version = "0.20.3", features = [ "server" ] }
 log = { version = "0.4.20", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [
 	"derive",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 publish = false
 repository = { workspace = true }
-version = "0.1.0"
+version = "0.1.2"
 
 [dependencies]
 clap = { workspace = true }
@@ -54,9 +54,7 @@ substrate-frame-rpc-system = { workspace = true }
 substrate-prometheus-endpoint = { workspace = true }
 
 # Polkadot
-polkadot-cli = { workspace = true, features = [
-	"rococo-native",
-] }
+polkadot-cli = { workspace = true, features = [ "rococo-native" ] }
 polkadot-primitives = { workspace = true }
 xcm = { workspace = true }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,13 +8,13 @@ repository = { workspace = true }
 version = "0.1.0"
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = [ "x86_64-unknown-linux-gnu" ]
 
 [dependencies]
 hex-literal = { workspace = true, optional = true }
 log = { workspace = true }
-parity-scale-codec = { workspace = true, features = ["derive"] }
-scale-info = { workspace = true, features = ["derive"] }
+parity-scale-codec = { workspace = true, features = [ "derive" ] }
+scale-info = { workspace = true, features = [ "derive" ] }
 smallvec = { workspace = true }
 
 # Substrate
@@ -81,7 +81,7 @@ sp-io = { workspace = true }
 substrate-wasm-builder = { workspace = true }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
 	"assets-common/std",
 	"cumulus-pallet-aura-ext/std",
@@ -194,4 +194,4 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
-experimental = ["pallet-aura/experimental"]
+experimental = [ "pallet-aura/experimental" ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ description = "A generic parachain runtime template"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
-version = "0.1.0"
+version = "0.1.2"
 
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]


### PR DESCRIPTION
This PR bumps the version for `runtime` and `node` to `0.1.2`, to be consistent with the changelog we have.
From now on, we should remember to bump the version in the code whenever we make some changes to changelog.

Also, somehow, github decided to merge the previous PR before tests have successfully passed (happens sometimes 🤷). And there was a cargo.toml formatting error. This PR also fixes that.


