### PR TITLE
add zombienet configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ venv.bak/
 # Documentation
 docs/node_modules
 docs/build
+
+# zombienet stuff
+zombienet-macos
+zombienet-linux-x64
+bin-*

--- a/scripts/zombienet.sh
+++ b/scripts/zombienet.sh
@@ -72,7 +72,8 @@ zombienet_devnet() {
   zombienet_init
   cargo build --release
   echo "spawning rococo-local relay chain plus devnet as a parachain..."
-  ./$ZOMBIENET_BIN spawn zombienet-config/devnet.toml -p native
+  local dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+  ./$ZOMBIENET_BIN spawn "$dir/../zombienet-config/devnet.toml" -p native
 }
 
 

--- a/zombienet-config/README.md
+++ b/zombienet-config/README.md
@@ -1,0 +1,23 @@
+# Zombienet configuration
+
+Zombienet aims to be a testing framework for Substrate based blockchains, providing a simple cli tool that allows users to spawn and test ephemeral networks.
+
+## Start a development chain
+
+Firstly build Polkadot binaries with:
+
+```sh
+$ scripts/zombienet.sh build
+```
+
+This process can take some time, so please be patient. If on Linux, you can alternatively download the binaries to speed up the process with:
+
+```shell
+$ scripts/zombinet.sh init
+```
+
+Once Polkadot binaries are in place you can spawn a local testnet by running the following command:
+
+```shell
+$ scripts/zombienet.sh devnet
+```

--- a/zombienet-config/devnet.toml
+++ b/zombienet-config/devnet.toml
@@ -1,0 +1,31 @@
+[relaychain]
+chain = "rococo-local"
+default_command = "./bin-v1.6.0/polkadot"
+
+	[[relaychain.nodes]]
+	name = "alice"
+	validator = true
+
+	[[relaychain.nodes]]
+	name = "bob"
+	validator = true
+
+[[parachains]]
+id = 1000
+addToGenesis = true
+cumulus_based = true
+chain = "dev"
+
+	[[parachains.collators]]
+	name = "collator01"
+	command = "./target/release/parachain-template-node"
+	ws_port = 9933
+	rpc_port = 8833
+	args = ["--rpc-max-connections 10000"]
+
+	[[parachains.collators]]
+	name = "collator02"
+	ws_port = 9822
+	rpc_port = 8822
+	command = "./target/release/parachain-template-node"
+	args = ["--rpc-max-connections 10000"]

--- a/zombienet.sh
+++ b/zombienet.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+ZOMBIENET_V=v1.3.91
+POLKADOT_V=v1.6.0
+
+case "$(uname -s)" in
+    Linux*)     MACHINE=Linux;;
+    Darwin*)    MACHINE=Mac;;
+    *)          exit 1
+esac
+
+if [ $MACHINE = "Linux" ]; then
+  ZOMBIENET_BIN=zombienet-linux-x64
+elif [ $MACHINE = "Mac" ]; then
+  ZOMBIENET_BIN=zombienet-macos
+fi
+
+BIN_DIR=bin-$POLKADOT_V
+
+build_polkadot() {
+  echo "cloning polkadot repository..."
+  CWD=$(pwd)
+  mkdir -p "$BIN_DIR"
+  pushd /tmp
+    git clone https://github.com/paritytech/polkadot-sdk.git
+    pushd polkadot-sdk
+      git checkout release-polkadot-$POLKADOT_V
+      echo "building polkadot executable..."
+      cargo build --release --features fast-runtime
+      cp target/release/polkadot "$CWD/$BIN_DIR"
+      cp target/release/polkadot-execute-worker "$CWD/$BIN_DIR"
+      cp target/release/polkadot-prepare-worker "$CWD/$BIN_DIR"
+    popd
+  popd
+}
+
+fetch_polkadot() {
+  echo "fetching from polkadot repository..."
+  echo $BIN_DIR
+  mkdir -p "$BIN_DIR"
+  pushd "$BIN_DIR"
+    wget https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-$POLKADOT_V/polkadot
+    wget https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-$POLKADOT_V/polkadot-execute-worker
+    wget https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-$POLKADOT_V/polkadot-prepare-worker
+    chmod +x *
+  popd
+}
+
+zombienet_init() {
+  if [ ! -f $ZOMBIENET_BIN ]; then
+    echo "fetching zombienet executable..."
+    curl -LO https://github.com/paritytech/zombienet/releases/download/$ZOMBIENET_V/$ZOMBIENET_BIN
+    chmod +x $ZOMBIENET_BIN
+  fi
+  if [ ! -f $BIN_DIR/polkadot ]; then
+    fetch_polkadot
+  fi
+}
+
+zombienet_build() {
+  if [ ! -f $ZOMBIENET_BIN ]; then
+    echo "fetching zombienet executable..."
+    curl -LO https://github.com/paritytech/zombienet/releases/download/$ZOMBIENET_V/$ZOMBIENET_BIN
+    chmod +x $ZOMBIENET_BIN
+  fi
+  if [ ! -f $BIN_DIR/polkadot ]; then
+    build_polkadot
+  fi
+}
+
+zombienet_devnet() {
+  zombienet_init
+  cargo build --release
+  echo "spawning rococo-local relay chain plus devnet as a parachain..."
+  ./$ZOMBIENET_BIN spawn zombienet-config/devnet.toml -p native
+}
+
+
+print_help() {
+  echo "This is a shell script to automate the execution of zombienet."
+  echo ""
+  echo "$ ./zombienet.sh init         # fetches zombienet and polkadot executables"
+  echo "$ ./zombienet.sh build        # builds polkadot executables from source"
+  echo "$ ./zombienet.sh devnet       # spawns a rococo-local relay chain plus parachain devnet-local as a parachain"
+}
+
+SUBCOMMAND=$1
+case $SUBCOMMAND in
+  "" | "-h" | "--help")
+    print_help
+    ;;
+  *)
+    shift
+    zombienet_${SUBCOMMAND} $@
+    if [ $? = 127 ]; then
+      echo "Error: '$SUBCOMMAND' is not a known SUBCOMMAND." >&2
+      echo "Run './zombienet.sh --help' for a list of known subcommands." >&2
+        exit 1
+    fi
+  ;;
+esac


### PR DESCRIPTION
This PR adds zombienet utilities to the template.

By running

```bash
$ ./zombienet.sh build && ./zombienet.sh devnet
```

it will spawn a local relay chain and parachain. Pretty useful for testing features within the project.

Please note whenever the template is prepared for async backing zombienet configuration will have to be updated. For more info see [here](https://github.com/OpenZeppelin/polkadot-runtime-template/commit/f34feff9293cf42fb4163f68382474bb6d0bc42c).